### PR TITLE
Remove Hard Dependency, Expanded Dependency, Added Contact Info, Updated Mod Version Number

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.6
 
 # Mod Properties
-	mod_version = 3.0.0
+	mod_version = 3.0.1
 	maven_group = com.github.levoment.chestlootmodifier
 	archives_base_name = [1.19] Chest Loot Modifier
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -9,8 +9,9 @@
     "Levoment"
   ],
   "contact": {
-    "homepage": "",
-    "sources": ""
+    "homepage": "https://github.com/Levoment/ChestLootModifier",
+    "sources": "https://github.com/Levoment/ChestLootModifier",
+    "issues": "https://github.com/Levoment/ChestLootModifier/issues"
   },
 
   "license": "The Unlicense",
@@ -28,8 +29,8 @@
 
   "depends": {
     "fabricloader": ">=0.14.6",
-    "fabric": "0.55.2+1.19",
-    "minecraft": "1.19",
+    "fabric": "*",
+    "minecraft": "1.19.x",
     "java": ">=17"
   },
   "suggests": {


### PR DESCRIPTION
I had someone looking to use MC Dungeons Weapons with your mod, but there was a conflict with the Fabric versions. Upon looking at your mod, I noticed that the Fabric Dependency was hard coded, so this PR will make it so that it can accept a range of Fabric Versions. I also updated the mod version to 3.0.1 since that appeared to be the schema that you had used in the past for minor changes.

It also allows for the mod to be loaded, potentially, in 1.19.1, assuming that no code needed to be changed. I have not tested that, but it will continue to load in 1.19 without issue.

I also added contact information to the `fabric.mod.json` file so that if there are any issues with loading the mod, the Fabric Loader should provide the link to the end user.

Thanks, so much, for your awesome contribution to the Minecraft Modding Community! I hope you have an amazing day/night!